### PR TITLE
Change order of targets to draw metric last

### DIFF
--- a/module/util.py
+++ b/module/util.py
@@ -187,7 +187,6 @@ class GraphFactory(object):
             graphite_metric = GraphiteMetric(self.prefix, self.hostname,
                                              self.cfg.graphite_data_source,
                                              self.servicename, metric['name'], self.postfix)
-            graph.add_target(graphite_metric, alias=metric['name'], color='green')
 
             #TODO - Shinken appears to store these in graphite, rather than using the current value as a constant line,
             #TODO - use the approppriate time series from graphite
@@ -198,6 +197,8 @@ class GraphFactory(object):
                 if t in metric:
                     n = 'color_%s' % t
                     graph.add_target('constantLine(%s)' % metric[t], alias=t.title(), color=getattr(self.cfg, n))
+
+            graph.add_target(graphite_metric, alias=metric['name'], color='green')
 
             v = dict(
                 link=graph.url('composer'),

--- a/tests/test.py
+++ b/tests/test.py
@@ -552,8 +552,8 @@ class TestGraphFactory(unittest.TestCase):
         uris = fact.get_graph_uris()
         self.assertEqual(len(uris), 1)
         self.assertEqual(uris[0], {
-            'link': 'http://example.com/graphite/composer/?width=586&height=308&fontSize=8&from=00:00_19700101&until=14:53_19700102&title=testhost/testservice - testMetric&target=alias(color(testhost.testservice.testMetric,"green"),"testMetric")&target=alias(constantLine(600),"Warning")&target=alias(constantLine(500),"Critical")&target=alias(constantLine(0),"Min")&target=alias(constantLine(3.7),"Max")',
-            'img_src': 'http://example.com/graphite/render/?width=586&height=308&fontSize=8&from=00:00_19700101&until=14:53_19700102&title=testhost/testservice - testMetric&target=alias(color(testhost.testservice.testMetric,"green"),"testMetric")&target=alias(constantLine(600),"Warning")&target=alias(constantLine(500),"Critical")&target=alias(constantLine(0),"Min")&target=alias(constantLine(3.7),"Max")'
+            'link': 'http://example.com/graphite/composer/?width=586&height=308&fontSize=8&from=00:00_19700101&until=14:53_19700102&title=testhost/testservice - testMetric&target=alias(constantLine(600),"Warning")&target=alias(constantLine(500),"Critical")&target=alias(constantLine(0),"Min")&target=alias(constantLine(3.7),"Max")&target=alias(color(testhost.testservice.testMetric,"green"),"testMetric")',
+            'img_src': 'http://example.com/graphite/render/?width=586&height=308&fontSize=8&from=00:00_19700101&until=14:53_19700102&title=testhost/testservice - testMetric&target=alias(constantLine(600),"Warning")&target=alias(constantLine(500),"Critical")&target=alias(constantLine(0),"Min")&target=alias(constantLine(3.7),"Max")&target=alias(color(testhost.testservice.testMetric,"green"),"testMetric")'
         })
 
     def test_service_generate_graphite_path_mods(self):
@@ -575,8 +575,8 @@ class TestGraphFactory(unittest.TestCase):
         uris = fact.get_graph_uris()
         self.assertEqual(len(uris), 1)
         self.assertEqual(uris[0], {
-            'link': 'http://example.com/graphite/composer/?width=586&height=308&fontSize=8&from=00:00_19700101&until=14:53_19700102&title=testhost/testservice - testMetric&target=alias(color(frank.testhost.shinken.testservice.testMetric.FRED,"green"),"testMetric")&target=alias(constantLine(600),"Warning")&target=alias(constantLine(500),"Critical")&target=alias(constantLine(0),"Min")&target=alias(constantLine(3.7),"Max")',
-            'img_src': 'http://example.com/graphite/render/?width=586&height=308&fontSize=8&from=00:00_19700101&until=14:53_19700102&title=testhost/testservice - testMetric&target=alias(color(frank.testhost.shinken.testservice.testMetric.FRED,"green"),"testMetric")&target=alias(constantLine(600),"Warning")&target=alias(constantLine(500),"Critical")&target=alias(constantLine(0),"Min")&target=alias(constantLine(3.7),"Max")'
+            'link': 'http://example.com/graphite/composer/?width=586&height=308&fontSize=8&from=00:00_19700101&until=14:53_19700102&title=testhost/testservice - testMetric&target=alias(constantLine(600),"Warning")&target=alias(constantLine(500),"Critical")&target=alias(constantLine(0),"Min")&target=alias(constantLine(3.7),"Max")&target=alias(color(frank.testhost.shinken.testservice.testMetric.FRED,"green"),"testMetric")',
+            'img_src': 'http://example.com/graphite/render/?width=586&height=308&fontSize=8&from=00:00_19700101&until=14:53_19700102&title=testhost/testservice - testMetric&target=alias(constantLine(600),"Warning")&target=alias(constantLine(500),"Critical")&target=alias(constantLine(0),"Min")&target=alias(constantLine(3.7),"Max")&target=alias(color(frank.testhost.shinken.testservice.testMetric.FRED,"green"),"testMetric")'
         })
 
 


### PR DESCRIPTION
Currently the graph line for the metric is drawn first, followed by that for the various attributes such as warning, critical, min and max. In cases where the metric follows the value of an attribute exactly, only the
attribute is seen because it is drawn later. This can make it appear that the metric is not there!

This change places the metric last so that it will always be visible. A side effect is that the metric is also listed last in the legend.

If this is undesirable for some, I suggest introducing a configuration option to allow a choice.
